### PR TITLE
fix: unexpected decoding behavior due to cheerio package version (#6)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ hexo.extend.filter.register('after_post_render', function(postInfo) {
 });
 
 function updateHeadingIndexes(options, data) {
-    var $ = cheerio.load(data, { decodeEntities: false });
+    var $ = cheerio.load(data, { xml: { xmlMode: false, decodeEntities: false } });
     var headings = $('h1, h2, h3, h4, h5, h6');
 
     var headingContextStack = [];

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/r12f/hexo-heading-index#readme",
   "dependencies": {
-    "cheerio": "^0.22.0"
+    "cheerio": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Update cheerio version to latest v1.0.0 can resolve this problem.

Also remove value 'excerpt' from variable 'contentKeys'. It might lead to render blank content for post excerpt in Home Page when using hexo-theme-next v8.22.0.